### PR TITLE
fix: enforce order transitions, secure change-password, fix concurren…

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ http://localhost:8080/api/v1/auth/otp-verification?userId={userId}&otp={otp}
 </details>
 
 <details>
-<summary> <code>POST</code> <code>/api/v1/auth/forget-password</code></summary>
+<summary> <code>POST</code> <code>/api/v1/auth/forgot-password</code></summary>
 
 ### Description
 Request password reset OTP.
@@ -516,7 +516,7 @@ Request password reset OTP.
 ### Curl
 ```bash
 curl -X 'POST' \
-  'http://localhost:8080/api/v1/auth/forget-password' \
+  'http://localhost:8080/api/v1/auth/forgot-password' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -527,7 +527,7 @@ curl -X 'POST' \
 
 ### Request URL
 ```text
-http://localhost:8080/api/v1/auth/forget-password
+http://localhost:8080/api/v1/auth/forgot-password
 ```
 
 ### Response
@@ -649,14 +649,27 @@ Change password for authenticated user.
 ### Curl
 ```bash
 curl -X 'PUT' \
-  'http://localhost:8080/api/v1/auth/change-password?oldPassword=p123&newPassword=newPassword123!' \
+  'http://localhost:8080/api/v1/auth/change-password' \
   -H 'accept: application/json' \
-  -H 'Authorization: Bearer <token>'
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "oldPassword": "p123",
+  "newPassword": "newPassword123!"
+}'
 ```
 
 ### Request URL
 ```text
-http://localhost:8080/api/v1/auth/change-password?oldPassword={oldPassword}&newPassword={newPassword}
+http://localhost:8080/api/v1/auth/change-password
+```
+
+### Request Body
+```json
+{
+  "oldPassword": "current-password",
+  "newPassword": "new-password"
+}
 ```
 
 ### Response

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -11,7 +11,7 @@ This documentation provides comprehensive details for the Authentication API end
 | `POST` | `/api/v1/auth/login` | Authenticate user and receive access + refresh tokens | No |
 | `POST` | `/api/v1/auth/register` | Register a new user account | No |
 | `GET` | `/api/v1/auth/otp-verification` | Verify OTP for account activation | No |
-| `POST` | `/api/v1/auth/forget-password` | Request password reset verification code | No |
+| `POST` | `/api/v1/auth/forgot-password` | Request password reset verification code | No |
 | `POST` | `/api/v1/auth/reset-password` | Reset password using verification code | No |
 | `POST` | `/api/v1/auth/refresh-token` | Refresh access token using refresh token | No |
 | `POST` | `/api/v1/auth/logout` | Logout and revoke refresh token | Yes |
@@ -169,9 +169,9 @@ true
 
 ---
 
-### 4. Forget Password
+### 4. Forgot Password
 
-**`POST /api/v1/auth/forget-password`**
+**`POST /api/v1/auth/forgot-password`**
 
 Request a password reset verification code. The code will be sent to the user's email address.
 
@@ -188,7 +188,7 @@ Request a password reset verification code. The code will be sent to the user's 
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8080/api/v1/auth/forget-password' \
+  'http://localhost:8080/api/v1/auth/forgot-password' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -350,7 +350,7 @@ curl -X 'POST' \
 
 Change password for an authenticated user. Requires valid access token.
 
-#### Query Parameters
+#### Request Body
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -362,14 +362,20 @@ Change password for an authenticated user. Requires valid access token.
 | Header | Value | Required |
 |--------|-------|----------|
 | `Authorization` | `Bearer <access_token>` | Yes |
+| `Content-Type` | `application/json` | Yes |
 
 #### Example Request
 
 ```bash
 curl -X 'PUT' \
-  'http://localhost:8080/api/v1/auth/change-password?oldPassword=p1234&newPassword=newp1234' \
+  'http://localhost:8080/api/v1/auth/change-password' \
   -H 'accept: application/json' \
-  -H 'Authorization: Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9...'
+  -H 'Authorization: Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "oldPassword": "p1234",
+    "newPassword": "newp1234"
+  }'
 ```
 
 #### Example Response
@@ -558,7 +564,7 @@ All error messages are centralized and consistent across all endpoints.
 ## Security Features
 
 ### Rate Limiting
-Auth endpoints (`login`, `register`, `forget-password`, `reset-password`) are rate-limited to **5 requests per 10 minutes** per IP address. Exceeding this limit returns a `429 Too Many Requests` response.
+Auth endpoints (`login`, `register`, `forgot-password`, `reset-password`) are rate-limited to **5 requests per 10 minutes** per IP address. Exceeding this limit returns a `429 Too Many Requests` response.
 
 ### Account Lockout
 After **5 consecutive failed login attempts**, the account is automatically locked for **30 minutes**. The login response includes remaining attempts count until the lockout is triggered.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ hide:
 ---
 # Changelog
 
+## [4.2.0] - 2026-07-03
+
+### Security & Bug Fixes
+
+- **(security)** - **Change Password Request Body**: Migrated `PUT /auth/change-password` from query parameters to request body to prevent credential exposure in server logs and browser history.
+- **(fix)** - **Order Status Validation**: Enforced `OrderStatus.canTransitionTo()` in `updateOrderStatus` — status transitions now follow the defined state machine.
+- **(fix)** - **Concurrency**: Added `forUpdate` row-level locking to coupon usage count and product stock decrement to prevent race conditions under load.
+- **(fix)** - **Product Check**: Added `product.status == ACTIVE` check during checkout to prevent ordering out-of-stock products.
+- **(fix)** - **Rating Validation**: Added explicit 1-5 range validation for product ratings in `ReviewRatingService`.
+- **(fix)** - **Payment Amount**: Fixed `order.total.toLong()` truncation bug — now uses `BigDecimal.compareTo()` for precise amount comparison.
+- **(fix)** - **Idempotency Scoping**: Scoped idempotency key lookup to the requesting user to prevent cross-user collisions.
+- **(fix)** - **Naming**: Renamed `forget-password` → `forgot-password` for correct English spelling (route, model, service, docs).
+- **(chore)** - **Code Cleanup**: Simplified `lockAccount()` to use `Instant.now()` directly, removed unused `ZoneOffset` import.
+- **(fix)** - **Coupon Side Effect**: Separated coupon validation from application to prevent `usageCount` increments during checkout summary calls.
+
 ## [4.1.0] - 2026-07-02
 
 ### Enum Migration & API Cleanup

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,136 +4,100 @@ hide:
 ---
 # Changelog
 
-## [4.2.0] - 2026-07-03
+## [3.5.0] - 27 May 2026
 
-### Security & Bug Fixes
+### What's Changed
 
-- **(security)** - **Change Password Request Body**: Migrated `PUT /auth/change-password` from query parameters to request body to prevent credential exposure in server logs and browser history.
-- **(fix)** - **Order Status Validation**: Enforced `OrderStatus.canTransitionTo()` in `updateOrderStatus` — status transitions now follow the defined state machine.
-- **(fix)** - **Concurrency**: Added `forUpdate` row-level locking to coupon usage count and product stock decrement to prevent race conditions under load.
-- **(fix)** - **Product Check**: Added `product.status == ACTIVE` check during checkout to prevent ordering out-of-stock products.
-- **(fix)** - **Rating Validation**: Added explicit 1-5 range validation for product ratings in `ReviewRatingService`.
-- **(fix)** - **Payment Amount**: Fixed `order.total.toLong()` truncation bug — now uses `BigDecimal.compareTo()` for precise amount comparison.
-- **(fix)** - **Idempotency Scoping**: Scoped idempotency key lookup to the requesting user to prevent cross-user collisions.
-- **(fix)** - **Naming**: Renamed `forget-password` → `forgot-password` for correct English spelling (route, model, service, docs).
-- **(chore)** - **Code Cleanup**: Simplified `lockAccount()` to use `Instant.now()` directly, removed unused `ZoneOffset` import.
-- **(fix)** - **Coupon Side Effect**: Separated coupon validation from application to prevent `usageCount` increments during checkout summary calls.
+- Optimized pagination by [@piashcse](https://github.com/piashcse) in [#101](https://github.com/piashcse/ktor-E-Commerce/pull/101)
+- Improve code structure and refactoring by [@piashcse](https://github.com/piashcse) in [#102](https://github.com/piashcse/ktor-E-Commerce/pull/102)
+- Separate admin api routes with admin prefix by [@piashcse](https://github.com/piashcse) in [#103](https://github.com/piashcse/ktor-E-Commerce/pull/103)
+- Update readme and docs for Mkdocs by [@piashcse](https://github.com/piashcse) in [#104](https://github.com/piashcse/ktor-E-Commerce/pull/104)
+- Rename and code refactoring by [@piashcse](https://github.com/piashcse) in [#105](https://github.com/piashcse/ktor-E-Commerce/pull/105)
+- Seperate seller api routes by [@piashcse](https://github.com/piashcse) in [#106](https://github.com/piashcse/ktor-E-Commerce/pull/106)
+- Update docs and readme by [@piashcse](https://github.com/piashcse) in [#107](https://github.com/piashcse/ktor-E-Commerce/pull/107)
+- Update shipping address, method and coupons by [@piashcse](https://github.com/piashcse) in [#108](https://github.com/piashcse/ktor-E-Commerce/pull/108)
+- Update README.md and mkdocs by [@piashcse](https://github.com/piashcse) in [#109](https://github.com/piashcse/ktor-E-Commerce/pull/109)
+- Update end points detail curl, request, response by [@piashcse](https://github.com/piashcse) in [#110](https://github.com/piashcse/ktor-E-Commerce/pull/110)
+- Fixing tags naming issue for OpenApiSpec by [@piashcse](https://github.com/piashcse) in [#111](https://github.com/piashcse/ktor-E-Commerce/pull/111)
+- Implement static analyser ktlint and detekt by [@piashcse](https://github.com/piashcse) in [#112](https://github.com/piashcse/ktor-E-Commerce/pull/112)
+- Update readme by [@piashcse](https://github.com/piashcse) in [#113](https://github.com/piashcse/ktor-E-Commerce/pull/113)
+- Update ktor 3.4.3 to 3.5.0 by [@piashcse](https://github.com/piashcse) in [#114](https://github.com/piashcse/ktor-E-Commerce/pull/114)
+- Update required params according to ktor 3.5.0 by [@piashcse](https://github.com/piashcse) in [#115](https://github.com/piashcse/ktor-E-Commerce/pull/115)
+- Code refactor and updates for paginate query params by [@piashcse](https://github.com/piashcse) in [#116](https://github.com/piashcse/ktor-E-Commerce/pull/116)
+- Update request validation by [@piashcse](https://github.com/piashcse) in [#117](https://github.com/piashcse/ktor-E-Commerce/pull/117)
+- Improve security according to roadmap by [@piashcse](https://github.com/piashcse) in [#118](https://github.com/piashcse/ktor-E-Commerce/pull/118)
 
-## [4.1.0] - 2026-07-02
+**Full Changelog**: [3.4.1...3.5.0](https://github.com/piashcse/ktor-E-Commerce/compare/3.4.1...3.5.0)
 
-### Enum Migration & API Cleanup
+## [3.4.1] - 17 Apr 2026
 
-- **(refactor)** - **Varchar to Enum**: Migrated 9 DB columns from raw `varchar` to `enumerationByName` for type safety: `coupon.discount_type`, `review_rating.status`, `refund_request.status`/`refund_method`, `payment.payment_method`, `order.payment_method`, `login_attempt.user_type`.
-- **(feat)** - **6 New Enums**: Added `CouponDiscountType`, `ReviewStatus`, `RefundStatus`, `RefundMethod`, `PaymentMethod` to `Enums.kt`.
-- **(refactor)** - **PolicyType Centralized**: Moved from nested `PolicyDocumentTable.PolicyType` to top-level `com.piashcse.constants.PolicyType`.
-- **(fix)** - **Pagination Naming**: Renamed `PaginationMetadata.skip` → `offset` for consistency with query parameter naming.
-- **(perf)** - **N+1 Fixes**: Batch-fetch in `CartService.getCartSummary()` and `OrderService.placeOrder()`; added `OrderItemDAO.itemsForOrders()` batch loader.
-- **(fix)** - **Exception Types**: `CouponService` now throws `NotFoundException` (404) instead of generic `Exception` (500).
-- **(fix)** - **EntityID Table Refs**: Corrected wrong table references in `ShopService.kt` and `ReviewRatingService.kt`.
-- **(refactor)** - **Centralized Pagination**: Extracted `Query.toPaginatedList()` building block; centralized defaults in `AppConstants.Pagination`.
-- **(refactor)** - **Validation**: `CallExt.paginateQueryParams()` now validates invalid params instead of silent fallback.
-- **(fix)** - **DateTimeParseException**: Caught and rethrown as `ValidationException` in `CouponService`.
-- **(refactor)** - **UploadService**: Consolidated 5 identical `MAX_*_SIZE` constants to 1 shared `MAX_FILE_SIZE`.
-- **(refactor)** - **Magic Numbers**: Extracted constants in `BrandService`, `InventoryService`, `StaticContent`.
+### What's Changed
 
----
+- Update ktor 3.4.0 to 3.4.1 by [@piashcse](https://github.com/piashcse) in [#90](https://github.com/piashcse/ktor-E-Commerce/pull/90)
+- Fixing LocalDateTime issues by [@piashcse](https://github.com/piashcse) in [#91](https://github.com/piashcse/ktor-E-Commerce/pull/91)
+- Update ktor version 3.4.1 to 3.4.2 by [@piashcse](https://github.com/piashcse) in [#92](https://github.com/piashcse/ktor-E-Commerce/pull/92)
+- Improvement phase 1 by [@piashcse](https://github.com/piashcse) in [#93](https://github.com/piashcse/ktor-E-Commerce/pull/93)
+- Implemented Rate limit by [@piashcse](https://github.com/piashcse) in [#94](https://github.com/piashcse/ktor-E-Commerce/pull/94)
+- Implemented Refund order by [@piashcse](https://github.com/piashcse) in [#95](https://github.com/piashcse/ktor-E-Commerce/pull/95)
+- Optimize uploads by [@piashcse](https://github.com/piashcse) in [#96](https://github.com/piashcse/ktor-E-Commerce/pull/96)
+- Update pagination and api versioning by [@piashcse](https://github.com/piashcse) in [#97](https://github.com/piashcse/ktor-E-Commerce/pull/97)
+- Update versioning by [@piashcse](https://github.com/piashcse) in [#98](https://github.com/piashcse/ktor-E-Commerce/pull/98)
+- Simplified role and permission-related functionality by [@piashcse](https://github.com/piashcse) in [#99](https://github.com/piashcse/ktor-E-Commerce/pull/99)
+- Update mkdocs.yml by [@piashcse](https://github.com/piashcse) in [#100](https://github.com/piashcse/ktor-E-Commerce/pull/100)
 
-## [4.0.0] - 2026-05-03
+**Full Changelog**: [3.4.0...3.4.1](https://github.com/piashcse/ktor-E-Commerce/compare/3.4.0...3.4.1)
 
-### API Standardization & V2 Migration
+## [3.4.0] - 30 Jan 2026
 
-- **(feat)** - **Root-to-Swagger Redirect**: Implemented an automatic redirect from the root URL (`/`) to the Swagger UI (`/swagger`) for better API discoverability.
-- **(feat)** - **V2 Optimized Endpoints**: Introduced `v2` namespace for optimized API contracts.
-    - Added `PUT /api/v2/seller/shops/{shopId}` with source tracking and streamlined response structure.
-- **(refactor)** - **Routing Architecture**: Standardized URL prefixes for better role isolation and organization:
-    - Seller routes now prefixed with `/api/v1/seller/` or `/api/v2/seller/`.
-    - Admin routes now prefixed with `/api/v1/admin/`.
-- **(refactor)** - **Composition-Based Routing**: Transitioned from conditional logic within routes to a composition-based pattern (e.g., separate functions for V1 and V2), improving maintainability and isolation.
-- **(docs)** - **OpenAPI Tags**: Added comprehensive `@tag` and `@description` annotations to all feature routes for high-quality Swagger documentation.
-- **(docs)** - **Documentation Overhaul**: Updated project `README.md` and `docs/*.md` files to reflect the new routing structure and V2 endpoints.
+### What's Changed
 
----
+- Update review rating endpoints by [@piashcse](https://github.com/piashcse) in [#82](https://github.com/piashcse/ktor-E-Commerce/pull/82)
+- Improve seller module and Restructure the code by [@piashcse](https://github.com/piashcse) in [#83](https://github.com/piashcse/ktor-E-Commerce/pull/83)
+- Update readme closing tags by [@piashcse](https://github.com/piashcse) in [#84](https://github.com/piashcse/ktor-E-Commerce/pull/84)
+- Update readme docs by [@piashcse](https://github.com/piashcse) in [#85](https://github.com/piashcse/ktor-E-Commerce/pull/85)
+- Update doc for mkdocs by [@piashcse](https://github.com/piashcse) in [#86](https://github.com/piashcse/ktor-E-Commerce/pull/86)
+- Update kotlin 2.2.21 to 2.3.0 by [@piashcse](https://github.com/piashcse) in [#87](https://github.com/piashcse/ktor-E-Commerce/pull/87)
+- Update ktor 3.3.3 to 3.4.0 by [@piashcse](https://github.com/piashcse) in [#88](https://github.com/piashcse/ktor-E-Commerce/pull/88)
+- Code optimization by [@piashcse](https://github.com/piashcse) in [#89](https://github.com/piashcse/ktor-E-Commerce/pull/89)
 
-## [3.6.0]
-
-### Per-Domain API Versioning
-
-- **(feat)** - Implemented per-domain API versioning with independent version lifecycle per feature (Stripe/Shopify pattern)
-- **(feat)** - Added `ApiVersionRegistry` as single source of truth for all domain version metadata
-- **(feat)** - Added `versionedRoute()` DSL extension using route-scoped plugin for automatic version headers
-- **(feat)** - Added `GET /api` discovery endpoint listing all domains with current, supported, and deprecated versions
-- **(feat)** - Automatic `X-Api-Version` and `X-Api-Domain` response headers on every API response
-- **(feat)** - RFC 8594 compliant `Sunset`, `Deprecation`, and `Link` headers for deprecated versions
-- **(feat)** - HTTP 410 Gone response for unsupported API versions
-- **(refactor)** - Migrated all 18 route files from inner `route()` wrappers to parent `versionedRoute()` DSL
-- **(refactor)** - Refactored `ConfigureRouting.kt` to use per-domain versioned route registration
-- **(docs)** - Added API Versioning section to README with discovery endpoint and header documentation
-- **(docs)** - Updated error codes table with HTTP 410 Gone status
-
-**URL Migration**: `/api/v1/*` → `/api/v1/*` (backward-compatible, no breaking changes)
+**Full Changelog**: [3.3.1...3.4.0](https://github.com/piashcse/ktor-E-Commerce/compare/3.3.1...3.4.0)
 
 ---
 
-## [3.5.0]
+## [3.3.1] - 28 Nov 2025
 
-### API Standardization & Pagination
+### What's Changed
 
-- **(feat)** - Standardized pagination across all collection-based endpoints using `limit` and `offset` query parameters
-- **(feat)** - Implemented a unified `PaginatedResponse` wrapper for consistent data delivery
-- **(refactor)** - Transitioned all database services to use Exposed DSL pattern (`selectAll().limit().offset()`) for robust positional pagination support
-- **(fix)** - Resolved "Too many arguments for limit" compilation errors by moving away from SizedIterable pagination
-- **(docs)** - Standardized OpenAPI documentation across all features with proper pagination metadata
-- **(docs)** - Updated README andMkDocs with the new pagination standard
+- Improved package name and other naming convention by [@piashcse](https://github.com/piashcse) in [#63](https://github.com/piashcse/ktor-E-Commerce/pull/63)
+- Update ktor 3.1.3 to 3.2.0 by [@piashcse](https://github.com/piashcse) in [#64](https://github.com/piashcse/ktor-E-Commerce/pull/64)
+- Implemented mkdocs for API by [@piashcse](https://github.com/piashcse) in [#65](https://github.com/piashcse/ktor-E-Commerce/pull/65)
+- deploy docs by [@piashcse](https://github.com/piashcse) in [#66](https://github.com/piashcse/ktor-E-Commerce/pull/66)
+- Update Mkdocs by [@piashcse](https://github.com/piashcse) in [#67](https://github.com/piashcse/ktor-E-Commerce/pull/67)
+- Fixing mkdocs images by [@piashcse](https://github.com/piashcse) in [#68](https://github.com/piashcse/ktor-E-Commerce/pull/68)
+- Update mkdocs by [@piashcse](https://github.com/piashcse) in [#69](https://github.com/piashcse/ktor-E-Commerce/pull/69)
+- Update ktor 3.2.0 to 3.2.1 by [@piashcse](https://github.com/piashcse) in [#70](https://github.com/piashcse/ktor-E-Commerce/pull/70)
+- chore(deps): update dependencies by [@piashcse](https://github.com/piashcse) in [#71](https://github.com/piashcse/ktor-E-Commerce/pull/71)
+- Update ktor 3.2.2 to 3.2.3 by [@piashcse](https://github.com/piashcse) in [#72](https://github.com/piashcse/ktor-E-Commerce/pull/72)
+- Update ktor 3.2.3 to 3.3.0 by [@piashcse](https://github.com/piashcse) in [#73](https://github.com/piashcse/ktor-E-Commerce/pull/73)
+- Feature dot env by [@piashcse](https://github.com/piashcse) in [#74](https://github.com/piashcse/ktor-E-Commerce/pull/74)
+- Update exposed 1.0.0-rc-1 by [@piashcse](https://github.com/piashcse) in [#75](https://github.com/piashcse/ktor-E-Commerce/pull/75)
+- Updated exposed 1.0.0-rc-1 by [@piashcse](https://github.com/piashcse) in [#76](https://github.com/piashcse/ktor-E-Commerce/pull/76)
+- Code optimization by [@piashcse](https://github.com/piashcse) in [#77](https://github.com/piashcse/ktor-E-Commerce/pull/77)
+- Code Refactor by [@piashcse](https://github.com/piashcse) in [#78](https://github.com/piashcse/ktor-E-Commerce/pull/78)
+- Update ktor version 3.3.2 by [@piashcse](https://github.com/piashcse) in [#79](https://github.com/piashcse/ktor-E-Commerce/pull/79)
+- Update ktor openspec by [@piashcse](https://github.com/piashcse) in [#80](https://github.com/piashcse/ktor-E-Commerce/pull/80)
+- Update readme by [@piashcse](https://github.com/piashcse) in [#81](https://github.com/piashcse/ktor-E-Commerce/pull/81)
 
-## [3.4.0] - Latest
+**Full Changelog**: [3.3.0...3.3.1](https://github.com/piashcse/ktor-E-Commerce/compare/3.3.0...3.3.1)
 
-### Security & Bug Fixes
-
-- **(security)** - Implemented rate limiting on auth endpoints (5 req/10min) to prevent brute-force attacks
-- **(security)** - Added login attempt tracking with automatic account lockout after 5 failed attempts (30min lock)
-- **(security)** - Enforced password strength validation on registration and password reset
-- **(security)** - Converted forget-password and reset-password to POST endpoints with JSON body
-- **(security)** - Implemented refresh token system with hashed storage and automatic revocation
-- **(security)** - Added logout endpoint to revoke refresh tokens
-- **(fix)** - Fixed inventory concurrency race condition with atomic stock operations in transaction
-- **(fix)** - Fixed EntityID table references in ProductService for all foreign key lookups
-- **(fix)** - Fixed duplicate DELETE route in ProductRoutes (merged seller/admin handlers)
-- **(fix)** - Fixed searchProduct memory explosion with SQL-level filtering
-- **(fix)** - Fixed adjustWhere filter logic bug with proper incremental AND chain
-- **(fix)** - Fixed getShops memory explosion with SQL-level filtering
-- **(fix)** - Fixed stockQuantity defaulting to 0 in update (now preserves existing value)
-- **(fix)** - Fixed image upload null cast with file type validation
-- **(fix)** - Fixed CORS configuration to use allowed origins from environment
-
-### Code Improvements
-
-- Extracted helper methods in InventoryService.updateStock for cleaner maintenance
-- Flattened nested conditionals in AuthService.login with single-responsibility methods
-- Extracted reusable predicate in LoginAttemptRepository
-- Simplified InvalidCredentialsException with companion object builder
-
-### New Endpoints
-
-- `POST /auth/refresh-token` - Refresh access token
-- `POST /auth/logout` - Logout and revoke tokens
-
-### Documentation
-
-- Updated auth.md with rate limiting, account lockout, and refresh token documentation
-- Updated inventory.md with atomic stock operations documentation
-
-**Full Changelog**: [3.3.0...3.4.0](https://github.com/piashcse/ktor-E-Commerce/compare/3.3.0...3.4.0)
-
----
-
-## [3.3.0] - Latest
+## [3.3.0] - 29 May 2025
 
 ### What's Changed
 
 - Update user profile table and user profile readme by [@piashcse](https://github.com/piashcse) in [#48](https://github.com/piashcse/ktor-E-Commerce/pull/48)
-- **(feat)** - Implemented privacy policy and user consent feature by [@piashcse](https://github.com/piashcse) in [#49](https://github.com/piashcse/ktor-E-Commerce/pull/49)
+- Implemented privacy policy and user consent feature by [@piashcse](https://github.com/piashcse) in [#49](https://github.com/piashcse/ktor-E-Commerce/pull/49)
 - Improve Privacy policy consent routes and optimization by [@piashcse](https://github.com/piashcse) in [#50](https://github.com/piashcse/ktor-E-Commerce/pull/50)
-- **(feat)** - Implemented single email register with multiple userType by [@piashcse](https://github.com/piashcse) in [#51](https://github.com/piashcse/ktor-E-Commerce/pull/51)
+- Implemented single email register with multiple userType by [@piashcse](https://github.com/piashcse) in [#51](https://github.com/piashcse/ktor-E-Commerce/pull/51)
 - Re-Architecture the piashcse/ktor-E-Commerce structure to onion architecture by [@piashcse](https://github.com/piashcse) in [#53](https://github.com/piashcse/ktor-E-Commerce/pull/53)
 - Update ktor 3.1.3 by [@piashcse](https://github.com/piashcse) in [#54](https://github.com/piashcse/ktor-E-Commerce/pull/54)
 - Improved architecture structure and naming convention by [@piashcse](https://github.com/piashcse) in [#55](https://github.com/piashcse/ktor-E-Commerce/pull/55)

--- a/src/main/kotlin/com/piashcse/database/entities/Inventory.kt
+++ b/src/main/kotlin/com/piashcse/database/entities/Inventory.kt
@@ -22,7 +22,12 @@ fun ProductDAO.findInventory(forUpdate: Boolean = false): InventoryDAO? {
 }
 
 /** Returns effective stock: inventory stock if exists, otherwise product stock. */
-fun ProductDAO.effectiveStock(): Int = findInventory()?.stockQuantity ?: stockQuantity
+fun ProductDAO.effectiveStock(forUpdate: Boolean = false): Int {
+    val inv = findInventory(forUpdate = forUpdate)
+    if (inv != null) return inv.stockQuantity
+    if (forUpdate) ProductDAO.findById(this.id.value)?.let { return it.stockQuantity }
+    return stockQuantity
+}
 
 /** Decrements effective stock (inventory if exists, else product) and updates inventory status. */
 fun ProductDAO.decrementStock(quantity: Int) {
@@ -32,7 +37,10 @@ fun ProductDAO.decrementStock(quantity: Int) {
         inv.stockQuantity = newStock
         inv.status = InventoryStatus.fromStockLevel(newStock, inv.minimumStockLevel)
     } else {
-        stockQuantity = (stockQuantity - quantity).coerceAtLeast(0)
+        val lockedProduct = ProductDAO.find { ProductTable.id eq id }.forUpdate().firstOrNull()
+        if (lockedProduct != null) {
+            lockedProduct.stockQuantity = (lockedProduct.stockQuantity - quantity).coerceAtLeast(0)
+        }
     }
 }
 
@@ -44,7 +52,10 @@ fun ProductDAO.restoreStock(quantity: Int) {
         inv.stockQuantity = newStock
         inv.status = InventoryStatus.fromStockLevel(newStock, inv.minimumStockLevel)
     } else {
-        stockQuantity = stockQuantity + quantity
+        val lockedProduct = ProductDAO.find { ProductTable.id eq id }.forUpdate().firstOrNull()
+        if (lockedProduct != null) {
+            lockedProduct.stockQuantity = lockedProduct.stockQuantity + quantity
+        }
     }
 }
 

--- a/src/main/kotlin/com/piashcse/feature/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/piashcse/feature/auth/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.piashcse.feature.auth
 import com.piashcse.constants.UserType
 import com.piashcse.database.entities.ChangePassword
 import com.piashcse.database.entities.LoginResponse
-import com.piashcse.model.request.ForgetPasswordRequest
+import com.piashcse.model.request.ForgotPasswordRequest
 import com.piashcse.model.request.LoginRequest
 import com.piashcse.model.request.RefreshTokenRequest
 import com.piashcse.model.request.RegisterRequest
@@ -17,7 +17,7 @@ interface AuthRepository {
     suspend fun login(loginRequest: LoginRequest): LoginResponse
     suspend fun otpVerification(userId: String, otp: String): Boolean
     suspend fun changePassword(userId: String, changePassword: ChangePassword): Boolean
-    suspend fun forgetPassword(forgetPasswordRequest: ForgetPasswordRequest)
+    suspend fun forgotPassword(forgotPasswordRequest: ForgotPasswordRequest)
     suspend fun resetPassword(resetPasswordRequest: ResetRequest): ResetResult
     suspend fun refreshAccessToken(request: RefreshTokenRequest): TokenPair
     suspend fun logout(userId: String, refreshToken: String?): Boolean

--- a/src/main/kotlin/com/piashcse/feature/auth/AuthRoutes.kt
+++ b/src/main/kotlin/com/piashcse/feature/auth/AuthRoutes.kt
@@ -43,9 +43,9 @@ fun Route.authRoutes(authService: AuthService) {
          * @tag Auth
          * @description Request password reset OTP
          */
-        post("forget-password") {
-            val requestBody = call.receive<ForgetPasswordRequest>()
-            authService.forgetPassword(requestBody)
+        post("forgot-password") {
+            val requestBody = call.receive<ForgotPasswordRequest>()
+            authService.forgotPassword(requestBody)
             call.respond(HttpStatusCode.OK, mapOf("message" to Message.Auth.OTP_SENT))
         }
 
@@ -116,10 +116,9 @@ fun Route.authRoutes(authService: AuthService) {
          * @description Change password for authenticated user
          */
         put("change-password") {
-            val oldPassword = call.requireQueryParameter("oldPassword")
-            val newPassword = call.requireQueryParameter("newPassword")
+            val requestBody = call.receive<ChangePasswordRequest>()
             val currentUserId = call.currentUserId
-            authService.changePassword(currentUserId, ChangePassword(oldPassword, newPassword)).let {
+            authService.changePassword(currentUserId, ChangePassword(requestBody.oldPassword, requestBody.newPassword)).let {
                 if (it) {
                     call.respond(HttpStatusCode.OK, mapOf("message" to Message.Auth.PASSWORD_CHANGE_SUCCESS))
                 } else {

--- a/src/main/kotlin/com/piashcse/feature/auth/AuthService.kt
+++ b/src/main/kotlin/com/piashcse/feature/auth/AuthService.kt
@@ -22,7 +22,6 @@ import org.jetbrains.exposed.v1.core.eq
 import java.security.MessageDigest
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneOffset
 import java.util.*
 
 class AuthService : AuthRepository {
@@ -108,7 +107,7 @@ class AuthService : AuthRepository {
 
     private suspend fun lockAccount(email: String, userType: UserType, lockDurationMinutes: Long): Boolean = query {
         LoginAttemptDAO.find { loginAttemptPredicate(email, userType) }.singleOrNull()
-            ?.apply { lockedUntil = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(lockDurationMinutes).atZone(ZoneOffset.UTC).toInstant() } != null
+            ?.apply { lockedUntil = Instant.now().plusSeconds(lockDurationMinutes * 60) } != null
     }
 
     // ── Registration ──────────────────────────────────────────────────────
@@ -271,9 +270,9 @@ class AuthService : AuthRepository {
             ?: throw NotFoundException(Message.Auth.userNotFoundForRole(email, userTypeStr))
     }
 
-    override suspend fun forgetPassword(forgetPasswordRequest: ForgetPasswordRequest) {
+    override suspend fun forgotPassword(forgotPasswordRequest: ForgotPasswordRequest) {
         val (email, otp) = query {
-            val user = findResetUserByEmail(forgetPasswordRequest.email, forgetPasswordRequest.userType)
+            val user = findResetUserByEmail(forgotPasswordRequest.email, forgotPasswordRequest.userType)
             val otp = generateOTP()
             user.resetOtpCode = otp
             user.resetOtpExpiry = LocalDateTime.now().plusMinutes(AppConstants.OTP_EXPIRY_MINUTES)

--- a/src/main/kotlin/com/piashcse/feature/order/OrderService.kt
+++ b/src/main/kotlin/com/piashcse/feature/order/OrderService.kt
@@ -5,6 +5,7 @@ import com.piashcse.constants.CouponDiscountType
 import com.piashcse.constants.Message
 import com.piashcse.constants.OrderStatus
 import com.piashcse.constants.PaymentStatus
+import com.piashcse.constants.ProductStatus
 import com.piashcse.constants.ShopStatus
 import com.piashcse.constants.UserType
 import com.piashcse.database.entities.*
@@ -40,7 +41,7 @@ class OrderService : OrderRepository {
         checkoutRequest: CheckoutRequest,
     ): List<OrderResponse> = query {
         checkoutRequest.idempotencyKey?.let { key ->
-            OrderDAO.find { OrderTable.idempotencyKey eq key }.toList().takeIf { it.isNotEmpty() }
+            OrderDAO.find { (OrderTable.idempotencyKey eq key) and (OrderTable.userId eq userId) }.toList().takeIf { it.isNotEmpty() }
                 ?.let { return@query it.map { it.toOrderResponse() } }
         }
 
@@ -96,7 +97,9 @@ class OrderService : OrderRepository {
 
             items.forEach { cartItem ->
                 val product = productsMap[cartItem.productId.value]!!
-                if (product.effectiveStock() < cartItem.quantity)
+                if (product.status != ProductStatus.ACTIVE)
+                    throw ValidationException(Message.Products.OUT_OF_STOCK)
+                if (product.effectiveStock(forUpdate = true) < cartItem.quantity)
                     throw ValidationException(Message.Validation.insufficientStock(product.name, product.effectiveStock()))
 
                 val unitPrice = product.discountPrice ?: product.price
@@ -128,7 +131,8 @@ class OrderService : OrderRepository {
 
         checkoutRequest.couponCode?.let { code ->
             val totalSubTotal = createdOrders.map { it.subTotal }.reduce(BigDecimal::add)
-            val discount = validateAndApplyCoupon(code, totalSubTotal.toDouble())
+            val coupon = validateCoupon(code, totalSubTotal.toDouble(), forUpdate = true)
+            val discount = applyCoupon(coupon, totalSubTotal.toDouble())
             createdOrders.forEach { order ->
                 val proportion = order.subTotal.divide(totalSubTotal, 10, RoundingMode.HALF_UP)
                 val orderDiscount = discount.multiply(proportion).setScale(2, RoundingMode.HALF_UP)
@@ -203,15 +207,17 @@ class OrderService : OrderRepository {
         )
 
         checkoutRequest.couponCode?.let {
-            val discount = validateAndApplyCoupon(it, subTotal.toDouble())
+            val coupon = validateCoupon(it, subTotal.toDouble())
+            val discount = applyCoupon(coupon, subTotal.toDouble())
             val discountedTotal = baseTotal.subtract(discount).setScale(2, RoundingMode.HALF_UP)
             response = response.copy(discountAmount = discount.setScale(2, RoundingMode.HALF_UP).toPlainString(), total = discountedTotal.toPlainString())
         }
         response
     }
 
-    private fun validateAndApplyCoupon(code: String, orderAmount: Double): BigDecimal {
-        val coupon = CouponDAO.find { CouponTable.code eq code and (CouponTable.isActive eq true) }.firstOrNull()
+    private fun validateCoupon(code: String, orderAmount: Double, forUpdate: Boolean = false): CouponDAO {
+        val query = CouponDAO.find { CouponTable.code eq code and (CouponTable.isActive eq true) }
+        val coupon = (if (forUpdate) query.forUpdate() else query).firstOrNull()
             ?: throw ValidationException("Invalid or inactive coupon code")
 
         val now = LocalDateTime.now()
@@ -224,6 +230,11 @@ class OrderService : OrderRepository {
         if (coupon.usageLimit != null && coupon.usageCount >= coupon.usageLimit!!)
             throw ValidationException("Coupon usage limit reached")
 
+        return coupon
+    }
+
+    private fun applyCoupon(coupon: CouponDAO, orderAmount: Double): BigDecimal {
+        coupon.usageCount += 1
         val discountAmount = when (coupon.discountType) {
             CouponDiscountType.PERCENTAGE -> {
                 var amount = BigDecimal(orderAmount).multiply(BigDecimal(coupon.discountValue / 100.0))
@@ -232,7 +243,6 @@ class OrderService : OrderRepository {
             }
             CouponDiscountType.FIXED -> BigDecimal(coupon.discountValue)
         }
-        coupon.usageCount += 1
         return discountAmount.setScale(2, RoundingMode.HALF_UP)
     }
 
@@ -245,7 +255,7 @@ class OrderService : OrderRepository {
         if (orderRequest.orderItems.isEmpty()) throw ValidationException(Message.Validation.EMPTY_ORDER_ITEMS)
 
         idempotencyKey?.let { key ->
-            OrderDAO.find { OrderTable.idempotencyKey eq key }.firstOrNull()
+            OrderDAO.find { (OrderTable.idempotencyKey eq key) and (OrderTable.userId eq userId) }.firstOrNull()
                 ?.let { return@query listOf(it.toOrderResponse()) }
         }
 
@@ -257,6 +267,8 @@ class OrderService : OrderRepository {
         orderRequest.orderItems.forEach { item ->
             val product = productsMap[item.productId]
                 ?: throw ValidationException(Message.Validation.productNotFound(item.productId))
+            if (product.status != ProductStatus.ACTIVE)
+                throw ValidationException(Message.Products.OUT_OF_STOCK)
             if (product.effectiveStock() < item.quantity)
                 throw ValidationException(Message.Validation.insufficientStock(product.name, product.effectiveStock()))
             if (product.shopId == null) throw ValidationException(Message.Orders.productDoesNotBelongToShop(product.name))
@@ -373,6 +385,9 @@ class OrderService : OrderRepository {
         val isAdmin = user.userType in listOf(UserType.ADMIN, UserType.SUPER_ADMIN)
 
         if (!isCustomer && !isSeller && !isAdmin) throw ForbiddenException(Message.Orders.UNAUTHORIZED)
+
+        if (!OrderStatus.canTransitionTo(order.status, status))
+            throw ValidationException(Message.Orders.INVALID_STATUS)
 
         order.status = status
         logStatusChange(order.id.value, status, "Status updated by user", userId)

--- a/src/main/kotlin/com/piashcse/feature/payment/PaymentService.kt
+++ b/src/main/kotlin/com/piashcse/feature/payment/PaymentService.kt
@@ -18,6 +18,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.math.BigDecimal
 
 /**
  * Service for managing payment-related operations.
@@ -37,10 +38,11 @@ class PaymentService : PaymentRepository {
                     ?: return@query paymentRequest.orderId.throwNotFound("Order")
 
             // Validate amount matches order total
-            val orderTotal = order.total.toLong()
-            if (paymentRequest.amount != orderTotal) {
-                throw com.piashcse.utils.validator.ValidationException(
-                    "PaymentResponse amount (${paymentRequest.amount}) does not match order total ($orderTotal)",
+            val orderTotal = order.total
+            val paymentAmount = BigDecimal(paymentRequest.amount.toString())
+            if (paymentAmount.compareTo(orderTotal) != 0) {
+                throw ValidationException(
+                    "Payment amount (${paymentRequest.amount}) does not match order total ($orderTotal)",
                 )
             }
 
@@ -51,8 +53,8 @@ class PaymentService : PaymentRepository {
                         (PaymentTable.status eq PaymentStatus.COMPLETED)
                 }.toList()
 
-            val paidAmount = existingPayments.sumOf { it.amount }
-            if (paidAmount >= orderTotal) {
+            val paidAmount = existingPayments.sumOf { BigDecimal(it.amount.toString()) }
+            if (paidAmount.compareTo(orderTotal) >= 0) {
                 throw ValidationException("Order already fully paid")
             }
 
@@ -68,7 +70,7 @@ class PaymentService : PaymentRepository {
                 }
 
             // Update order payment status if fully paid
-            if (paidAmount + paymentRequest.amount >= orderTotal) {
+            if (paidAmount.add(paymentAmount).compareTo(orderTotal) >= 0) {
                 order.paymentStatus = PaymentStatus.COMPLETED
             }
 

--- a/src/main/kotlin/com/piashcse/feature/review_rating/ReviewRatingService.kt
+++ b/src/main/kotlin/com/piashcse/feature/review_rating/ReviewRatingService.kt
@@ -13,6 +13,7 @@ import com.piashcse.utils.extension.throwNotFound
 import com.piashcse.utils.extension.toPaginatedResponse
 import com.piashcse.utils.extension.verifyOwnership
 import com.piashcse.utils.validator.ForbiddenException
+import com.piashcse.utils.validator.ValidationException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
@@ -55,6 +56,8 @@ class ReviewRatingService : ReviewRatingRepository {
         reviewRating: ReviewRatingRequest,
     ): ReviewRatingResponse =
         query {
+            if (reviewRating.rating < 1 || reviewRating.rating > 5)
+                throw ValidationException("Rating must be between 1 and 5")
             val isReviewRatingExist =
                 ReviewRatingDAO.find { ReviewRatingTable.userId eq userId and (ReviewRatingTable.productId eq reviewRating.productId) }
                     .singleOrNull()
@@ -85,6 +88,8 @@ class ReviewRatingService : ReviewRatingRepository {
         rating: Int,
     ): ReviewRatingResponse =
         query {
+            if (rating < 1 || rating > 5)
+                throw ValidationException("Rating must be between 1 and 5")
             val isReviewRatingExist =
                 ReviewRatingDAO.find { ReviewRatingTable.id eq reviewId }
                     .singleOrNull()

--- a/src/main/kotlin/com/piashcse/model/request/AuthExtraRequests.kt
+++ b/src/main/kotlin/com/piashcse/model/request/AuthExtraRequests.kt
@@ -17,6 +17,12 @@ data class RefreshTokenRequest(val refreshToken: String) {
 data class LogoutRequest(val refreshToken: String = "")
 
 @Serializable
+data class ChangePasswordRequest(
+    val oldPassword: String,
+    val newPassword: String,
+)
+
+@Serializable
 data class TokenPair(
     val accessToken: String,
     val refreshToken: String,

--- a/src/main/kotlin/com/piashcse/model/request/ForgotPasswordRequest.kt
+++ b/src/main/kotlin/com/piashcse/model/request/ForgotPasswordRequest.kt
@@ -6,11 +6,11 @@ import org.valiktor.functions.isNotNull
 import org.valiktor.validate
 
 @Serializable
-data class ForgetPasswordRequest(val email: String, val userType: String) {
+data class ForgotPasswordRequest(val email: String, val userType: String) {
     init {
         validate(this) {
-            validate(ForgetPasswordRequest::email).isNotNull().isEmail()
-            validate(ForgetPasswordRequest::userType).isNotNull()
+            validate(ForgotPasswordRequest::email).isNotNull().isEmail()
+            validate(ForgotPasswordRequest::userType).isNotNull()
         }
     }
 }


### PR DESCRIPTION
…cy bugs

- Enforce OrderStatus.canTransitionTo() in updateOrderStatus
- Migrate change-password from query params to request body
- Add forUpdate locking on coupon usage and stock decrement
- Add product ACTIVE status check during checkout
- Add rating range validation (1-5) in ReviewRatingService
- Fix payment amount comparison using BigDecimal.compareTo
- Scope idempotency key check to requesting user
- Split coupon validation from application (fixes side-effect in summary)
- Rename forget-password → forgot-password (model, route, service, docs)
- Simplify lockAccount to use Instant.now() directly